### PR TITLE
Keyword argument in `torch.autocast()`

### DIFF
--- a/mortal/train.py
+++ b/mortal/train.py
@@ -163,7 +163,7 @@ def train():
             q_target_mc = gamma ** steps_to_done * kyoku_rewards
             q_target_mc = q_target_mc.to(torch.float32)
 
-            with torch.autocast(device.type, enable_amp):
+            with torch.autocast(device.type, enabled=enable_amp):
                 if online:
                     mu_mortal, _ = mortal(obs)
                     q_out = current_dqn(mu_mortal, masks)


### PR DESCRIPTION
This PR resolves an error caused by a change in the keyword arguments in `torch.autocast()`.

The order of keyword arguments in `torch.autocast()` has changed, so you will get an error if you use the latest version of PyTorch. `torch.autocast()`’s second keyword argument is `enabled=` until PyTorch 1.10. Since 1.11, `dtype=` is the second keyword argument.

Reference:
* https://pytorch.org/docs/1.10/amp.html?highlight=autocast#torch.autocast
* https://pytorch.org/docs/stable/amp.html?highlight=autocast#torch.autocast 