### PR TITLE
Fix: add torch.device wrapper and error message for empty gameplay file

### DIFF
--- a/libriichi/src/dataset/gameplay.rs
+++ b/libriichi/src/dataset/gameplay.rs
@@ -162,8 +162,8 @@ impl GameplayLoader {
     pub fn load_events(&self, events: &[Event]) -> Result<Vec<Gameplay>> {
         let invisibles = self.oracle.then(|| Invisible::new(events, self.trust_seed));
 
-        let idxs: ArrayVec<[u8; 4]> = match &events[0] {
-            Event::StartGame { names, .. } => names
+        let idxs: ArrayVec<[u8; 4]> = match events.first() {
+            Some(Event::StartGame { names, .. }) => names
                 .iter()
                 .enumerate()
                 .filter(|(_, name)| {
@@ -174,6 +174,7 @@ impl GameplayLoader {
                 })
                 .map(|(i, _)| i as u8)
                 .collect(),
+            None => bail!("the event file is empty"),
             _ => bail!("the first event is not StartGame, got {:?}", events[0]),
         };
 

--- a/libriichi/src/dataset/gameplay.rs
+++ b/libriichi/src/dataset/gameplay.rs
@@ -174,8 +174,7 @@ impl GameplayLoader {
                 })
                 .map(|(i, _)| i as u8)
                 .collect(),
-            None => bail!("the event file is empty"),
-            _ => bail!("the first event is not StartGame, got {:?}", events[0]),
+            _ => bail!("empty or invalid game log"),
         };
 
         idxs.into_par_iter()

--- a/mortal/client.py
+++ b/mortal/client.py
@@ -14,7 +14,7 @@ from config import config
 
 def main():
     remote = (config['online']['remote']['host'], config['online']['remote']['port'])
-    device = config['control']['device']
+    device = torch.device(config['control']['device'])
     oracle = Brain(True, **config['resnet']).to(device).eval()
     mortal = Brain(False, **config['resnet']).to(device).eval()
     dqn = DQN().to(device)

--- a/mortal/engine.py
+++ b/mortal/engine.py
@@ -19,6 +19,7 @@ class MortalEngine:
         boltzmann_temp = 1,
     ):
         self.device = device or torch.device('cpu')
+        assert isinstance(device, torch.device)
         self.brain = brain.to(self.device).eval()
         self.dqn = dqn.to(self.device).eval()
         self.is_oracle = is_oracle

--- a/mortal/engine.py
+++ b/mortal/engine.py
@@ -19,7 +19,7 @@ class MortalEngine:
         boltzmann_temp = 1,
     ):
         self.device = device or torch.device('cpu')
-        assert isinstance(device, torch.device)
+        assert isinstance(self.device, torch.device)
         self.brain = brain.to(self.device).eval()
         self.dqn = dqn.to(self.device).eval()
         self.is_oracle = is_oracle


### PR DESCRIPTION
This PR resolves two runtime errors during the training process:

1. Add torch.device wrapper on device name. Without this wrapper, a confusing error "RuntimeError: failed to execute `react_batch` on Python engine" occurs.
2. Add friendly error message for empty gameplay file. Without this fix, rust panics with "index out of range".