### PR TITLE
Fix assertion failure in encode_obs

### DIFF
--- a/libriichi/src/state/obs_repr.rs
+++ b/libriichi/src/state/obs_repr.rs
@@ -279,7 +279,7 @@ impl<'a> ObsEncoderContext<'a> {
             }
         }
 
-        let v = state.tiles_left as f32 / 69.;
+        let v = state.tiles_left as f32 / 70.;
         self.arr.fill(self.idx, v);
         self.idx += 1;
 


### PR DESCRIPTION
`PlayerState.tiles_left` is 70 at new kyoku start, leading to the element in `arr` exceed the range [0,1].